### PR TITLE
ci: restrict /ci-run trigger to users with write access

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,21 @@ jobs:
       install-sys-deps: ${{ steps.pick.outputs.install_sys_deps }}
       pr-sha: ${{ steps.pick.outputs.pr_sha }}
     steps:
+      - name: Check write permission
+        if: github.event_name == 'issue_comment'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const { data: perm } = await github.rest.repos.getCollaboratorPermissionLevel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              username: context.payload.comment.user.login,
+            });
+            const level = perm.permission;  // admin, write, read, none
+            if (level !== 'admin' && level !== 'write') {
+              core.setFailed(`User ${context.payload.comment.user.login} has '${level}' permission, need 'write' or 'admin' to trigger CI.`);
+            }
+
       - name: Pick runner
         id: pick
         uses: actions/github-script@v7


### PR DESCRIPTION
## Summary

Adds a write-permission check before CI runs triggered by `/ci-run` comments.

## Change

Queries `repos.getCollaboratorPermissionLevel` API to verify the commenter
has `write` or `admin` permission. Fails the resolve job early with a clear
message if the user lacks sufficient permissions.

## Why

The `issue_comment` event fires for all commenters. Without this check,
any GitHub user could trigger CI on the repo by commenting `/ci-run` on a PR,
consuming CI resources.

## Usage (unchanged)

```
/ci-run              → GitHub-hosted runner (requires write access)
/ci-run-self-hosted  → self-hosted runner (requires write access)
```