### PR TITLE
fix: exclude Chinese deck from Sphinx page processing

### DIFF
--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -106,6 +106,7 @@ exclude_patterns = [
     "presentations/DNDSR_overview/parts/*.md",
     "presentations/DNDSR_overview/README.md",
     "presentations/DNDSR_overview.md",
+    "presentations/DNDSR_overview_zh.md",
 ]
 
 # -- Breathe configuration (C++ API from Doxygen XML) -----------------------


### PR DESCRIPTION
## Summary
Sphinx was processing `docs/presentations/DNDSR_overview_zh.md` as a source page and wrapping the rendered HTML in the Sphinx theme, breaking Marp's slide navigation. The English deck was already excluded; this adds the same exclusion for the Chinese assembled source.

## Changes
- `docs/sphinx/conf.py`: add `presentations/DNDSR_overview_zh.md` to `exclude_patterns`