### PR TITLE
ci: add Cantera build support, update cfd_externals submodule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,7 +158,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends \
-            cmake ninja-build ccache \
+            cmake ninja-build ccache doxygen \
             libopenmpi-dev openmpi-bin
 
       # ------------------------------------------------------------------
@@ -172,8 +172,10 @@ jobs:
           python-version: "3.12"
 
       # ------------------------------------------------------------------
-      # Clean cached directories so actions/cache is the sole source of
-      # truth (matters on self-hosted runners with persistent filesystems)
+      # 4. Clean cached directories so actions/cache is the sole source
+      #    of truth (matters on self-hosted runners with persistent
+      #    filesystems).  Must happen before cfd_externals build so the
+      #    install/ directory is clean for caching.
       # ------------------------------------------------------------------
       - name: Clean cached directories
         run: |
@@ -183,10 +185,20 @@ jobs:
                  external/nanoflann external/nlohmann external/pybind11 \
                  external/pybind11_json
           rm -rf external/cfd_externals/install
-          rm -rf venv
 
       # ------------------------------------------------------------------
-      # 4. Header-only externals (Eigen, Boost, CGAL, fmt, pybind11, ...)
+      # 4b. Minimal Python venv for cfd_externals build (Cantera deps)
+      # ------------------------------------------------------------------
+      - name: Create minimal Python venv
+        run: |
+          git submodule update --init --depth=1 external/cfd_externals
+          python3 -m venv venv
+          source venv/bin/activate
+          pip install --upgrade pip
+          pip install -r external/cfd_externals/requirements.txt
+
+      # ------------------------------------------------------------------
+      # 5. Header-only externals (Eigen, Boost, CGAL, fmt, pybind11, ...)
       # ------------------------------------------------------------------
       - name: Restore header-only externals cache
         id: cache-headeronlys
@@ -235,7 +247,7 @@ jobs:
           key: headeronlys-v1
 
       # ------------------------------------------------------------------
-      # 5. cfd_externals (zlib, hdf5, cgns, parmetis)
+      # 6. cfd_externals (zlib, hdf5, cgns, parmetis)
       # ------------------------------------------------------------------
       - name: Restore cfd_externals cache
         id: cache-cfd-ext
@@ -265,21 +277,19 @@ jobs:
           key: cfd-ext-${{ runner.os }}-${{ steps.submod.outputs.cfd_ext_sha }}
 
       # ------------------------------------------------------------------
-      # 6. Python venv
+      # 7. Full Python environment (h5py against cfd_externals HDF5, etc.)
       # ------------------------------------------------------------------
       - name: Restore Python venv cache
         id: cache-venv
         uses: actions/cache/restore@v4
         with:
           path: venv
-          key: venv-ci-${{ runner.os }}-${{ steps.submod.outputs.cfd_ext_sha }}-${{ hashFiles('requirements.txt', 'scripts/install_python_deps.sh') }}
+          key: venv-ci-${{ runner.os }}-${{ steps.submod.outputs.cfd_ext_sha }}-${{ hashFiles('requirements.txt', 'external/cfd_externals/requirements.txt', 'scripts/install_python_deps.sh') }}
 
-      - name: Install Python dependencies
+      - name: Install Python dependencies (full)
         if: steps.cache-venv.outputs.cache-hit != 'true'
         run: |
-          python3 -m venv venv
           source venv/bin/activate
-          pip install --upgrade pip
           PIP=$PWD/venv/bin/pip ./scripts/install_python_deps.sh
 
       - name: Save Python venv cache
@@ -287,10 +297,10 @@ jobs:
         uses: actions/cache/save@v4
         with:
           path: venv
-          key: venv-ci-${{ runner.os }}-${{ steps.submod.outputs.cfd_ext_sha }}-${{ hashFiles('requirements.txt', 'scripts/install_python_deps.sh') }}
+          key: venv-ci-${{ runner.os }}-${{ steps.submod.outputs.cfd_ext_sha }}-${{ hashFiles('requirements.txt', 'external/cfd_externals/requirements.txt', 'scripts/install_python_deps.sh') }}
 
       # ------------------------------------------------------------------
-      # 7. ccache
+      # 8. ccache
       # ------------------------------------------------------------------
       - name: Restore ccache
         if: needs.resolve.outputs.cache-ccache == 'true'
@@ -307,7 +317,7 @@ jobs:
         run: ccache --max-size=5G
 
       # ------------------------------------------------------------------
-      # 8. CMake configure
+      # 9. CMake configure
       # ------------------------------------------------------------------
       - name: CMake configure
         run: |
@@ -320,16 +330,16 @@ jobs:
           DNDS_TEST_MPIEXTRA: "--oversubscribe"
 
       # ------------------------------------------------------------------
-      # 9. Build C++ tests and solver executables
+      # 10. Build C++ tests and solver executables
       # ------------------------------------------------------------------
       - name: Build C++ unit tests
         run: cmake --build build -t all_unit_tests -j$(nproc)
 
       - name: Build Euler solvers
-        run: cmake --build build -t euler euler3D eulerSA eulerSA3D euler2EQ euler2EQ3D -j$(nproc)
+        run: cmake --build build -t euler euler3D eulerSA eulerSA3D euler2EQ euler2EQ3D eulerEX eulerEX3D -j$(nproc)
 
       # ------------------------------------------------------------------
-      # 10. Build pybind11 targets
+      # 11. Build pybind11 targets
       # ------------------------------------------------------------------
       - name: Build pybind11 modules
         run: |
@@ -346,13 +356,17 @@ jobs:
           cmake --install build --component py
 
       # ------------------------------------------------------------------
-      # 11. Run C++ tests
+      # 12. Run C++ tests
       # ------------------------------------------------------------------
       - name: Run C++ tests
-        run: ctest --test-dir build --output-on-failure --timeout 300
+        timeout-minutes: 30
+        run: ctest --test-dir build --output-on-failure --timeout 600
+        env:
+          DNDS_MECH_PATH: ${{ github.workspace }}/external/cfd_externals/install/data
+          CANTERA_DATA: ${{ github.workspace }}/external/cfd_externals/install/data
 
       # ------------------------------------------------------------------
-      # 12. Run Python tests
+      # 13. Run Python tests
       # ------------------------------------------------------------------
       - name: Run Python tests
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,6 +266,7 @@ jobs:
           fi
           rm -rf external/cfd_externals
           git submodule update --init --recursive --depth=1
+          source venv/bin/activate
           cd external/cfd_externals
           CC=mpicc CXX=mpicxx python3 cfd_externals_build.py
 

--- a/.gitignore
+++ b/.gitignore
@@ -48,9 +48,15 @@ srcOrig
 newSrc*
 .cache
 *.ipynb_*
+__pycache__
 # generated stubs (regenerated at install time by cmake/DndsTooling.cmake)
 stubs/
 *.pyi
 # temporary compile_commands.json for clangd generated with compile db
 /compile_commands.json
 /DNDSR
+.codegraph
+workspace
+/.opencode/**/local
+/session_backup
+.slim/deepwork/

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,12 +2,19 @@
 #
 # To set up the full dev environment, run:
 #
-#   ./scripts/install_python_deps.sh
+#   pip install -r external/cfd_externals/requirements.txt   # Cantera deps (first)
+#   <build cfd_externals>
+#   ./scripts/install_python_deps.sh                         # everything else (after)
 #
 # The script installs everything in this file, then builds h5py and mpi4py
 # from source against the project's HDF5 (cfd_externals) and MPI.  Those
 # two packages are deliberately excluded here because their PyPI wheels
 # bundle incompatible library versions that crash at import time.
+#
+# Packages needed to *build* the cfd_externals C libraries (scons,
+# packaging, ruamel.yaml, patchelf for Cantera) are listed separately
+# in external/cfd_externals/requirements.txt and must be installed FIRST,
+# before running cfd_externals_build.py.
 #
 # pyproject.toml [project.optional-dependencies].dev mirrors the formatter
 # tools below — keep the two lists in sync when editing.
@@ -31,6 +38,8 @@ auditwheel
 pybind11-stubgen
 typing_extensions
 compdb
+ninja
+cython
 
 # Testing
 pytest

--- a/scripts/install_python_deps.sh
+++ b/scripts/install_python_deps.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 # install_python_deps.sh — Install ALL Python dependencies for DNDSR.
 #
+# This script must be run AFTER building cfd_externals (HDF5, zlib, etc.).
+# The Cantera build deps (scons, packaging, ruamel.yaml, patchelf) should
+# already be installed from external/cfd_externals/requirements.txt before
+# running cfd_externals_build.py.
+#
 # This is the single entry point for setting up the Python environment.
 # It installs:
 #   1. Binary-wheel packages from requirements.txt  (numpy, scipy, pytest, …)
@@ -11,9 +16,11 @@
 # h5py and mpi4py MUST be compiled from source.  Binary wheels from PyPI
 # bundle their own HDF5/MPI libraries, which conflict with the versions
 # linked by the DNDSR pybind11 modules and cause crashes at import time.
+# --no-build-isolation avoids pip creating temporary venvs that would
+# reinstall build deps (including mpi4py when building h5py).
 #
 # Usage:
-#   ./scripts/install_python_deps.sh          # uses venv/bin/pip, auto-detect jobs
+#   ./scripts/install_python_deps.sh          # uses venv/bin/pip, auto-detect -j
 #   JOBS=8 ./scripts/install_python_deps.sh   # limit parallel compilation
 #   PIP=path/to/pip ./scripts/install_python_deps.sh
 #
@@ -72,7 +79,7 @@ echo "--- Installing mpi4py (from source, CC=$MPI_CC, -j$JOBS) ---"
 CC="$MPI_CC" \
     MAKEFLAGS="-j$JOBS" \
     CMAKE_BUILD_PARALLEL_LEVEL="$JOBS" \
-    "$PIP" install --no-binary mpi4py mpi4py --force-reinstall \
+    "$PIP" install --no-binary mpi4py --no-build-isolation mpi4py --force-reinstall \
     --verbose
 
 # ---- 4. h5py — compiled against the project's HDF5 (MPI-enabled) ---------
@@ -83,7 +90,7 @@ CC="$MPI_CC" \
     HDF5_MPI="ON" \
     MAKEFLAGS="-j$JOBS" \
     CMAKE_BUILD_PARALLEL_LEVEL="$JOBS" \
-    "$PIP" install --no-binary h5py h5py --force-reinstall \
+    "$PIP" install --no-binary h5py --no-build-isolation h5py --force-reinstall \
     --verbose
 
 echo ""


### PR DESCRIPTION
## Summary

This PR updates the CI workflow and cfd_externals submodule to support Cantera v3.2.0 as a build dependency.

## Changes

### Submodule
- Bump `external/cfd_externals` (adds Cantera v3.2.0, `requirements.txt`, build fixes)

### CI workflow (`.github/workflows/ci.yml`)
- Add `doxygen` to system dependencies
- Create minimal Python venv with Cantera build deps (`scons`, `packaging`, etc.) before building `cfd_externals`
- Update venv cache key to include `external/cfd_externals/requirements.txt`
- Add `eulerEX`, `eulerEX3D` to solver build targets
- Increase C++ test timeout to 600s, add `DNDS_MECH_PATH`/`CANTERA_DATA` env vars for reactive tests

### Script & deps
- Add `--no-build-isolation` flags to `mpi4py`/`h5py` source builds in `install_python_deps.sh`
- Add `ninja`, `cython` to `requirements.txt`
- Update `.gitignore` for workspace/opencode artifacts

## Notes
- The CI uses a two-stage venv approach: minimal venv (Cantera build deps) before `cfd_externals` build, then full venv after
- Cantera-dependent solver targets (`canteraConstVolTrajectory`, `eulerState`) and reactive-flow tests are NOT included — they depend on source changes in a separate feature branch